### PR TITLE
Bumped selenium and appium dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,9 @@ repositories {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    testCompile 'org.seleniumhq.selenium:selenium-remote-driver:3.13.0'
+    testCompile 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     testCompile 'org.testobject:testobject-appium-java-api:0.2.7'
     testCompile 'ch.qos.logback:logback-classic:1.2.3'
+    testCompile group: 'io.appium', name: 'java-client', version: '7.0.0'
 }
 


### PR DESCRIPTION
The old versions had issues accessing gamesys an d generali. Their URLs are slightly different from our regular production environment (`http://eu1.appium.testobject.com/wd/hub/` vs `https://gamesys.testobject.com/api/appium/wd/hub/`)